### PR TITLE
macOS universal build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   windows-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
         run: pip install -r requirements.txt pyinstaller
 
       - name: Run PyInstaller
-        run: pyinstaller main.py --distpath . --onefile --name traktor-obs-sync
+        run: pyinstaller main.py --distpath . --onefile --name traktor-obs-sync --target-arch universal2
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes #8 
macos-latest is now arm64 so targeting pyinstaller to "universal2" should work now.

https://github.com/actions/runner-images?tab=readme-ov-file#available-images